### PR TITLE
Slight performance boost, avoid sqrt()

### DIFF
--- a/backend/Entity.cpp
+++ b/backend/Entity.cpp
@@ -111,8 +111,8 @@ bool Entity::isType(ents::EntityType type) {
 
 bool Entity::intersects(Entity e) {
 	double distance = pow(e.getX()-x,2) + pow(e.getY()-y,2);
-	distance = sqrt(distance);
-	return distance < getHitSphere() + e.getHitSphere();
+	double testRadius = getHitSphere() + e.getHitSphere(); 
+	return distance < testRadius*testRadius;
 }
 
 bool Entity::intersects(Entity* e) {


### PR DESCRIPTION
This should operate the same, but avoid the expensive sqrt() function by comparing squared distances.